### PR TITLE
chore: align all build configs on C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 3.15)
 project(CloudStreamingArgsDebugger LANGUAGES CXX)
 
+# Use C++20 project-wide. The GitHub Actions build.yml invokes cl with
+# /std:c++20 directly; keep the CMake path in sync so the two build modes
+# compile the same language.
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 # Specify that this is a Win32 application with wWinMain entry point
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SUBSYSTEM:WINDOWS")
 

--- a/path_info.cpp
+++ b/path_info.cpp
@@ -30,8 +30,6 @@ template <typename Fill> std::wstring FillWithGrowingBuffer(Fill fill)
     for (int attempt = 0; attempt < 6; ++attempt)
     {
         SetLastError(ERROR_SUCCESS);
-        // `&buf[0]` yields `wchar_t*` in both C++17 and C++20; `buf.data()`
-        // would only do so in C++20. Tests compile with C++17.
         DWORD len = fill(&buf[0], static_cast<DWORD>(buf.size()));
         if (len == 0)
             return {};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,9 +4,11 @@ project(ArgumentDebuggerTests LANGUAGES CXX)
 # Explicitly specify that tests are console applications
 set(CMAKE_WIN32_EXECUTABLE OFF)
 
-# Set C++ standard
-set(CMAKE_CXX_STANDARD 17)
+# Set C++ standard (kept in sync with the top-level CMakeLists.txt and with
+# the /std:c++20 flag used by .github/workflows/build.yml).
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Find GoogleTest package
 find_package(GTest CONFIG REQUIRED)


### PR DESCRIPTION
## Summary
The project set the C++ standard in three places with three different answers:

| where | was |
|---|---|
| `.github/workflows/build.yml` (raw `cl`) | `/std:c++20` |
| `CMakeLists.txt` | unset (MSVC default, ≈ C++14) |
| `tests/CMakeLists.txt` | `CMAKE_CXX_STANDARD 17` |

This gap is why the previous path_info extraction compiled fine under the manual `/std:c++20` build but broke the CTest build: `std::wstring::data()` returns `const wchar_t*` in C++17 but `wchar_t*` in C++20, and the Win32 APIs want `LPWSTR`.

This PR:
- Sets `CMAKE_CXX_STANDARD 20` (required, extensions off) in both `CMakeLists.txt` files.
- Drops the now-moot C++17 vs C++20 note from `path_info.cpp` — the workaround (`&buf[0]`) is still there and still correct, it just doesn't need to advertise its reason any more.

## Test plan
- [ ] `build` / `windows-build`: no change (they already used `/std:c++20`).
- [ ] `test` (CTest): builds with C++20 now; GoogleTest supports C++20 fine.
- [ ] `Memory Safety Tests` (ASan Debug): same — MSVC ASan is C++20-compatible.